### PR TITLE
Do not output any content on the frontpage.

### DIFF
--- a/profiles/teampulse/teampulse.install
+++ b/profiles/teampulse/teampulse.install
@@ -578,4 +578,5 @@ $field1 = array(
     ->execute();
   variable_set('admin_theme', 'seven');
   variable_set('node_admin_theme', '1');
+  variable_set('site_frontpage', 'frontpage');
 }

--- a/sites/all/modules/custom/teampulse_defaults/teampulse_defaults.module
+++ b/sites/all/modules/custom/teampulse_defaults/teampulse_defaults.module
@@ -7,3 +7,21 @@ function teampulse_defaults_views_api() {
   return array('api' => 3.0);
 }
 
+/**
+ * Implements hook_menu().
+ */
+function teampulse_defaults_menu() {
+  return array(
+    'frontpage' => array(
+      'page callback' => 'teampulse_defaults_frontpage',
+    ),
+  );
+}
+
+/**
+ * Page callback for the frontpage.
+ */
+function teampulse_defaults_frontpage() {
+  // The front page does not have any content.
+  return '';
+}


### PR DESCRIPTION
The front page should not contain any custom content. Instead of using `/node` or a particular node for the front page we should use a custom page callback that returns an empty string. This will avoid needless queries to be executed on the front page.
